### PR TITLE
Update release links to be compatible with platform

### DIFF
--- a/docs/release/releases.md
+++ b/docs/release/releases.md
@@ -25,7 +25,7 @@
 
 ## sim4life.io/sim4life.science Platform
 
-### [Version: 1.75.0](https://github.com/ITISFoundation/osparc-issues/blob/master/release-notes/s4l/v1.75.0.md)
+<h3 id="v1.75.0"><a href="https://github.com/ITISFoundation/osparc-issues/blob/master/release-notes/s4l/v1.75.0.md">Version: 1.75.0</a></h3>
  - Release Date: 11.07.2024
  - [Changelog](https://github.com/ITISFoundation/osparc-issues/blob/master/release-notes/s4l/v1.75.0.md)
 


### PR DESCRIPTION
I have found a way to make it so that anchors are compatible with the "version tags" used by oSPARC `v1.75.0`.

Please use this format form now on. oSPARC will link to this page with the following url (which can be used to test after the merge):

https://github.com/ZurichMedTech/s4l-manual/blob/main/docs/release/releases.md#v1.75.0